### PR TITLE
validateEmail function var missing semicolon

### DIFF
--- a/sendgrid.cfc
+++ b/sendgrid.cfc
@@ -2235,7 +2235,7 @@ component output="false" displayname="SendGrid.cfc"  {
     var body = {
       'email': arguments.email,
       'source': arguments.source
-    }
+    };
 
     if( !len( variables.emailValidationApiKey ) ) {
       throw( "Use of email validation endpoint requires a separate API key. Please read the documentation for further details.");


### PR DESCRIPTION
Received `Invalid CFML construct found on line 2240 at column 5` error due to missing semicolon. (using ACF 2016.0.16.320445)