### PR TITLE
Remove leading/trailing quotes from email names

### DIFF
--- a/helpers/mail.cfc
+++ b/helpers/mail.cfc
@@ -741,7 +741,7 @@ component accessors="true" {
         var bracketedEmail = bracketedEmails[1];
         return {
           'email' : bracketedEmail.REReplace( '[<>]', '', 'all'),
-          'name' : email.replacenocase( bracketedEmail, '' ).trim()
+          'name' : email.replacenocase( bracketedEmail, '' ).trim().REReplace('^"','').REReplace('"$','')
         };
 
       } else {


### PR DESCRIPTION
I'm not sure if SendGrid ignores leading/trailing quotes in the email name, but I've always explicitly removed them just to be safe & consistent.

NOTE: Adobe (starting w/CF11) & Lucee both evaluate a full name & email address string (ie, `"me" <me@domain.com>`) as a valid email.
```
myEmail = '"me" <me@domain.com>';
writedump(isvalid("email", myEmail));  // true
```
If I test the same name/email string at third-party website [isEmail.info](http://isemail.info/%22me%22%20%3Cme%40domain.com%3E), the error response is: "Address contains text after a comment or Folding White Space". (I've been using their JAR file to additionally [validate DNS & MX records](https://gist.github.com/JamoCA/72cdcb77246ea0ee5820).)