### PR TITLE
Upgrade for new marketing campaigns/Single Sends

### DIFF
--- a/helpers/singlesend.cfc
+++ b/helpers/singlesend.cfc
@@ -20,8 +20,9 @@ component accessors="true" {
     setSent_to({});
     setEmail_config({});
 
-    if ( arguments.keyExists( 'name' ) )
+    if( arguments.keyExists( 'name' ) ){
       this.name( name );
+    }
 
     return this;
   }
@@ -30,31 +31,30 @@ component accessors="true" {
   * @hint Sets the name of the Single Send. This is required. The name must be at least 1 character long and can be up to 100 characters.
   */
   public any function name( required string name ) {
-    // validate minimum length
-    if( !name.len() ){
-      throw( type="InvalidArgumentException", message="The name must be at least 1 character long." );
-    }
-
-    // trim to 100 characters if longer
-    if( name.len() > 100 ){
-      name = name.left(100);
-    }
-
     setName( name );
     return this;
   }
 
-  // TODO: throw exception or slice if length exceeds 10
   /**
   * @hint Sets the categories for the Single Send. Maximum of 10 categories allowed.
+  * @categories can be passed in as an array or comma separated list. Lists will be converted to arrays
   */
-  public any function categories( required array categories ) {
-    // Ensure the array is not longer than 10 items
-    if( categories.len() > 10 ){
-      categories = categories.slice(1, 10);
+  public any function categories( required any categories ) {
+    if( isArray( categories ) ) {
+      setCategories( categories );
+    } else {
+      setCategories( categories.listToArray() );
     }
 
-    setCategories( categories );
+    return this;
+  }
+
+  /**
+  * @hint Appends a single category to campaigns array of categories
+  */
+  public any function addCategory( required string category ) {
+    variables.categories.append( category );
+
     return this;
   }
 
@@ -62,7 +62,6 @@ component accessors="true" {
   * @hint Sets the send time for the Single Send in ISO8601 timestamp format.
   */
   public any function send_at( required string timestamp ) {
-    timestamp = timestamp.dateTimeFormat('iso');
     setSend_at( timestamp );
     return this;
   }
@@ -72,30 +71,21 @@ component accessors="true" {
   * @send_to object can include list_ids, segment_ids, and the all flag.
   */
   public any function send_to( required struct send_to ) {
-    if( send_to.keyExists("list_ids") ){
-      if( !isArray(send_to.list_ids) ){
-        throw( type="InvalidArgumentException", message="list_ids must be an array of UUIDs." );
-      }
-      if( send_to.list_ids.len() > 50 ){
-        send_to.list_ids = send_to.list_ids.slice(1, 50);
-      }
-    }
-
-    // Validate segment_ids
-    if( send_to.keyExists("segment_ids") ){
-      if( !isArray(send_to.segment_ids) ){
-        throw( type="InvalidArgumentException", message="segment_ids must be an array of UUIDs." );
-      }
-      if( send_to.segment_ids.len() > 10 ){
-        send_to.segment_ids = send_to.segment_ids.slice(1, 10);
-      }
-    }
-
-    if( send_to.keyExists("all") && !isBoolean(send_to.all) ){
-      throw( type="InvalidArgumentException", message="The all property must be a boolean." );
-    }
-
     setSent_to( send_to );
+    return this;
+  }
+
+  /**
+  * @hint Sets the IDs of the lists you are sending this Single Send to. Maximum of 50 list IDs allowed. Note that you can have both segment IDs and list IDs. If any list Ids were previously set, this method overwrites them.
+  * @lists can be passed in as an array or comma separated list. Lists will be converted to arrays
+  */
+  public any function useLists( required any lists ) {
+    if( isArray( lists ) ) {
+      variables.sent_to["list_ids"] = lists;
+    } else {
+      variables.sent_to["list_ids"] = lists.listToArray();
+    }
+
     return this;
   }
 
@@ -103,13 +93,28 @@ component accessors="true" {
   * @hint Adds a list ID to the send_to object. Maximum of 50 list IDs allowed.
   */
   public any function addListId( required string listId ) {
-    if( !variables.sent_to.keyExists("list_ids") ){
-      variables.sent_to["list_ids"] = [];
-    }
-    if( variables.sent_to["list_ids"].len() >= 50 ){
-      throw( type="InvalidArgumentException", message="A maximum of 50 list IDs is allowed." );
-    }
     variables.sent_to["list_ids"].append(listId);
+    return this;
+  }
+
+  /**
+  * @hint Convenience method for adding a list ID to the send_to object. Delegates to `addListId()`
+  */
+  public any function useList( required numeric id ) {
+    addListId( id );
+  }
+
+  /**
+  * @hint Sets the segment IDs that you are sending this list to. Maximum of 10 segment IDs allowed. Note that you can have both segment IDs and list IDs. If any segment Ids were previously set, this method overwrites them.
+  * @segments can be passed in as an array or comma separated list. Lists will be converted to arrays
+  */
+  public any function useSegments( required any segments ) {
+    if( isArray( segments ) ) {
+      variables.sent_to["segment_ids"] = segments;
+    } else {
+      variables.sent_to["segment_ids"] = segments.listToArray();
+    }
+
     return this;
   }
 
@@ -117,81 +122,37 @@ component accessors="true" {
   * @hint Adds a segment ID to the send_to object. Maximum of 10 segment IDs allowed.
   */
   public any function addSegmentId( required string segmentId ) {
-    if( !variables.sent_to.keyExists("segment_ids") ){
-      variables.sent_to["segment_ids"] = [];
-    }
-    if( variables.sent_to["segment_ids"].len() >= 10 ){
-      throw( type="InvalidArgumentException", message="A maximum of 10 segment IDs is allowed." );
-    }
     variables.sent_to["segment_ids"].append(segmentId);
     return this;
+  }
+
+  /**
+  * @hint Convenience method for adding a segment ID to the send_to object. Delegates to `addSegmentId()`
+  */
+  public any function useSegment( required numeric id ) {
+    addSegmentId( id );
   }
 
   /**
   * @hint Sets the all flag in the send_to object.
   */
   public any function setAll( required boolean all ) {
-    if( !variables.sent_to.keyExists("all") ) {
-      variables.sent_to["all"] = false;
-    }
     variables.sent_to["all"] = all;
     return this;
   }
 
   /**
-  * @hint Configures the email content for the Single Send.
+  * @hint Configures the email content for the Single Send. Overwrites any properties that have previously been set.
   * @config is a struct containing email configuration details.
   */
   public any function emailConfig( required struct config ) {
-    if( config.keyExists("subject") ){
-      subject(config.subject);
-    }
-    if( config.keyExists("html_content") ){
-      htmlContent(config.html_content);
-    }
-    if( config.keyExists("plain_content") ){
-      plainContent(config.plain_content);
-    }
-    if( config.keyExists("generate_plain_content") ){
-      if( !isBoolean(config.generate_plain_content) ){
-        throw( type="InvalidArgumentException", message="generate_plain_content must be a boolean." );
-      }
-      variables.email_config["generate_plain_content"] = config.generate_plain_content;
-    }
-    if( config.keyExists( "design_id") ){
-      variables.email_config.delete("subject");
-      variables.email_config.delete("html_content");
-      variables.email_config.delete("plain_content");
-      variables.email_config["design_id"] = config.design_id;
-    }
-    if( config.keyExists("editor") ){
-      if( !(config.editor == "code" || config.editor == "design") ){
-        throw( type="InvalidArgumentException", message="editor must be 'code' or 'design'." );
-      }
-      variables.email_config["editor"] = config.editor;
-    }
-    if( !config.keyExists("suppression_group_id") && !config.keyExists("custom_unsubscribe_url") ){
-      throw( type="InvalidArgumentException", message="Either suppression_group_id or custom_unsubscribe_url must be provided." );
-    }
-    if( config.keyExists("suppression_group_id") ){
-      variables.email_config["suppression_group_id"] = config.suppression_group_id;
-    }
-    if( config.keyExists("custom_unsubscribe_url") ){
-      variables.email_config["custom_unsubscribe_url"] = config.custom_unsubscribe_url;
-    }
-    if( config.keyExists("sender_id") ){
-      senderId(config.sender_id);
-    }
-    if( config.keyExists("ip_pool") ){
-      variables.email_config["ip_pool"] = config.ip_pool;
-    }
-
     setEmail_config( variables.email_config );
     return this;
   }
 
   /**
   * @hint Convenience method for setting the subject of the email.
+  * @subject The subject line of the Single Send. Do not include this field if you are using a design_id.
   */
   public any function subject( required string subject ) {
     variables.email_config["subject"] = subject;
@@ -200,6 +161,7 @@ component accessors="true" {
 
   /**
   * @hint Convenience method for setting the HTML content of the email.
+  * @html The HTML content of the Single Send. Do not include this field if you are using a design_id.
   */
   public any function htmlContent( required string html ) {
     variables.email_config["html_content"] = html;
@@ -207,7 +169,15 @@ component accessors="true" {
   }
 
   /**
+  * @hint Redundant, but included for consistency in naming the methods for setting attributes. Delegates to `htmlContent()`
+  */
+  public any function html( required string html ) {
+    return htmlContent( html );
+  }
+
+  /**
   * @hint Convenience method for setting the plain text content of the email.
+  * @plain The plain text content of the Single Send. Do not include this field if you are using a design_id.
   */
   public any function plainContent( required string plain ) {
     variables.email_config["plain_content"] = plain;
@@ -215,11 +185,149 @@ component accessors="true" {
   }
 
   /**
+  * @hint Redundant, but included for consistency in naming the methods for setting attributes. Delegates to `plainContent()`
+  */
+  public any function plain( required string plain ) {
+    return plainContent( plain );
+  }
+
+  /**
+  * @hint Convenience method for generating plain content from the HTML content.
+  * @generate if true, the API will generate plain text content from the HTML content.
+  * @default true
+  */
+  public any function generatePlainContent( required boolean generate ) {
+    variables.email_config["generate_plain_content"] = generate;
+    return this;
+  }
+
+  /**
+  * @hint Convenience method for setting both html and plain at the same time. You can either pass in the HTML content, and both will be set from it (using a method to strip the HTML for the plain text version), or you can call the method without an argument, after having set the HTML, and that will be used.
+  */
+  public any function plainFromHtml( string message = '' ) {
+
+    if( !message.len() ) {
+
+      var htmlContent = variables.email_config["html_content"];
+
+      if( !htmlContent.len() ) {
+        throw( 'The html content needs to be set prior to calling #getFunctionCalledName()# without the message argument.' );
+      }
+
+      plain( removeHTML( htmlContent ) );
+
+    } else {
+      plain( removeHTML( message ) );
+      html( message );
+    }
+
+    return this;
+  }
+
+  /**
+  * @hint Convenience method for setting the design ID for the email.
+  * @designId can be used in place of the subject, HTML content, and/or plain content.
+  */
+  public any function designId( required string designId ) {
+    variables.email_config["design_id"] = designId;
+    return this;
+  }
+
+  /**
+  * @hint Convenience method for setting the editor type for the email.
+  * @editor can be "code" or "design".
+  * @default "code"
+  */
+  public any function editor( required string editor ) {
+    variables.email_config["editor"] = editor;
+    return this;
+  }
+
+  /**
+  * @hint The editor used in the UI. Because it defaults to `code`, it really only needs to be toggled to `design`
+  */
+  public any function useDesignEditor() {
+    editor( 'design' );
+    return this;
+  }
+
+  /**
+  * @hint The editor used in the UI. It defaults to `code`, so this shouldn't be needed, but it's provided for consistency.
+  */
+  public any function useCodeEditor() {
+    editor( 'code' );
+    return this;
+  }
+
+  /**
+  * @hint Convenience method for setting the suppression group ID.
+  * @id The ID of the Suppression Group to allow recipients to unsubscribe. You must provide this or the custom_unsubscribe_url.
+  */
+  public any function suppressionGroupId( required numeric id ) {
+    variables.email_config["suppression_group_id"] = id;
+    return this;
+  }
+
+  /**
+  * @hint Included in order to provide a more fluent interface; delegates to `suppressionGroupId()`
+  */
+  public any function useSuppressionGroup( required numeric id ) {
+    return suppressionGroupId( id );
+  }
+
+  /**
+  * @hint Convenience method for setting a custom unsubscribe URL.
+  * @url The URL allowing recipients to unsubscribe. You must provide this or the suppression_group_id.
+  */ 
+  public any function customUnsubscribeUrl( required string url ) {
+    variables.email_config["custom_unsubscribe_url"] = url;
+    return this;
+  }
+
+  /**
+  * @hint Included in order to provide a more fluent interface; delegates to `customUnsubscribeUrl()`
+  */
+  public any function useCustomUnsubscribeUrl( required string url ) {
+    return customUnsubscribeUrl( url );
+  }
+
+  /**
   * @hint Convenience method for setting the sender ID.
+  * @id The ID of the verified sender
   */
   public any function senderId( required numeric id ) {
     variables.email_config["sender_id"] = id;
     return this;
+  }
+
+  /**
+  * @hint Included in order to provide a more fluent interface; delegates to `senderId()`
+  */
+  public any function sender( required numeric id ) {
+    return senderId( id );
+  }
+
+  /**
+  * @hint Included in order to provide a more fluent interface; delegates to `senderId()`
+  */
+  public any function fromSender( required numeric id ) {
+    return senderId( id );
+  }
+
+  /**
+   * @hint Sets the IP Pool for the Single Send.
+   * @pool The name of the IP Pool from which the Single Send emails are sent.
+   */
+  public any function ipPool( required string pool ) {
+    variables.email_config["ip_pool"] = pool;
+    return this;
+  }
+
+  /**
+  * @hint Included in order to provide a more fluent interface; delegates to `ipPool()`
+  */
+  public any function fromIpPool( required string pool ) {
+    return ipPool( pool );
   }
 
   /**
@@ -237,45 +345,62 @@ component accessors="true" {
     return serializeJSON( body );
   }
 
-  // /**
-  // * @hint converts the array of properties to an array of their keys/values, while filtering those that have not been set
-  // */
-  // private array function getPropertyValues() {
+  /** This could probably go in a separate utils CFC, but it's here for now
+  * Removes All HTML from a string removing tags, script blocks, style blocks, and replacing special character code.
+  *
+  * @author Scott Bennett (scott@coldfusionguy.com)
+  * @version 1, November 14, 2007
+  */
+  private string function removeHTML( required string source ){
 
-  //   var propertyValues = getProperties().map(
-  //     function( item, index ) {
-  //       return {
-  //         "key" : item.name,
-  //         "value" : getPropertyValue( item.name )
-  //       };
-  //     }
-  //   );
+    // Remove all spaces becuase browsers ignore them
+    var result = ReReplace(trim(source), "[[:space:]]{2,}", " ","ALL");
 
-  //   return propertyValues.filter(
-  //     function( item, index ) {
-  //       if ( isStruct( item.value ) )
-  //         return !item.value.isEmpty();
-  //       else
-  //         return item.value.len();
-  //     }
-  //   );
-  // }
+    // Remove the header
+    result = ReReplace(result, "<[[:space:]]*head.*?>.*?</head>","", "ALL");
 
-  // private array function getProperties() {
+    // remove all scripts
+    result = ReReplace(result, "<[[:space:]]*script.*?>.*?</script>","", "ALL");
 
-  //   var metaData = getMetaData( this );
-  //   var properties = [];
+    // remove all styles
+    result = ReReplace(result, "<[[:space:]]*style.*?>.*?</style>","", "ALL");
 
-  //   for( var prop in metaData.properties ) {
-  //     properties.append( prop );
-  //   }
+    // insert tabs in spaces of <td> tags
+    result = ReReplace(result, "<[[:space:]]*td.*?>","  ", "ALL");
 
-  //   return properties;
-  // }
+    // insert line breaks in places of <BR> and <LI> tags
+    result = ReReplace(result, "<[[:space:]]*br[[:space:]]*>",chr(13), "ALL");
+    result = ReReplace(result, "<[[:space:]]*li[[:space:]]*>",chr(13), "ALL");
 
-  // private any function getPropertyValue( string key ){
-  //   var method = this["get#key#"];
-  //   var value = method();
-  //   return value;
-  // }
+    // insert line paragraphs (double line breaks) in place
+    // if <P>, <DIV> and <TR> tags
+    result = ReReplace(result, "<[[:space:]]*div.*?>",chr(13), "ALL");
+    result = ReReplace(result, "<[[:space:]]*tr.*?>",chr(13), "ALL");
+    result = ReReplace(result, "<[[:space:]]*p.*?>",chr(13), "ALL");
+
+    // Remove remaining tags like <a>, links, images,
+    // comments etc - anything thats enclosed inside < >
+    result = ReReplace(result, "<.*?>","", "ALL");
+
+    // replace special characters:
+    result = ReReplace(result, "&nbsp;"," ", "ALL");
+    result = ReReplace(result, "&bull;"," * ", "ALL");
+    result = ReReplace(result, "&lsaquo;","<", "ALL");
+    result = ReReplace(result, "&rsaquo;",">", "ALL");
+    result = ReReplace(result, "&trade;","(tm)", "ALL");
+    result = ReReplace(result, "&frasl;","/", "ALL");
+    result = ReReplace(result, "&lt;","<", "ALL");
+    result = ReReplace(result, "&gt;",">", "ALL");
+    result = ReReplace(result, "&copy;","(c)", "ALL");
+    result = ReReplace(result, "&reg;","(r)", "ALL");
+
+    // Remove all others. More special character conversions
+    // can be added above if needed
+    result = ReReplace(result, "&(.{2,6});", "", "ALL");
+
+    // Thats it.
+    return result;
+
+  }
+
 }

--- a/helpers/singlesend.cfc
+++ b/helpers/singlesend.cfc
@@ -1,0 +1,281 @@
+/**
+* sendgrid.cfc
+* Copyright 2017-2019 Matthew Clemente, John Berquist
+* Licensed under MIT (https://github.com/mjclemente/sendgrid.cfc/blob/master/LICENSE)
+*/
+component accessors="true" {
+
+  property name="name" default="";
+  property name="categories" default="";
+  property name="send_at" default="";
+  property name="sent_to" default="";
+  property name="email_config" default="";
+
+  /**
+  * @hint Initializes the Single Send with a name. The name is required to create a Single Send.
+  */
+  public any function init( string name ) {
+
+    setCategories([]);
+    setSent_to({});
+    setEmail_config({});
+
+    if ( arguments.keyExists( 'name' ) )
+      this.name( name );
+
+    return this;
+  }
+
+  /**
+  * @hint Sets the name of the Single Send. This is required. The name must be at least 1 character long and can be up to 100 characters.
+  */
+  public any function name( required string name ) {
+    // validate minimum length
+    if( !name.len() ){
+      throw( type="InvalidArgumentException", message="The name must be at least 1 character long." );
+    }
+
+    // trim to 100 characters if longer
+    if( name.len() > 100 ){
+      name = name.left(100);
+    }
+
+    setName( name );
+    return this;
+  }
+
+  // TODO: throw exception or slice if length exceeds 10
+  /**
+  * @hint Sets the categories for the Single Send. Maximum of 10 categories allowed.
+  */
+  public any function categories( required array categories ) {
+    // Ensure the array is not longer than 10 items
+    if( categories.len() > 10 ){
+      categories = categories.slice(1, 10);
+    }
+
+    setCategories( categories );
+    return this;
+  }
+
+  /**
+  * @hint Sets the send time for the Single Send in ISO8601 timestamp format.
+  */
+  public any function send_at( required string timestamp ) {
+    timestamp = timestamp.dateTimeFormat('iso');
+    setSend_at( timestamp );
+    return this;
+  }
+
+  /**
+  * @hint Sets the send_to object for the Single Send.
+  * @send_to object can include list_ids, segment_ids, and the all flag.
+  */
+  public any function send_to( required struct send_to ) {
+    if( send_to.keyExists("list_ids") ){
+      if( !isArray(send_to.list_ids) ){
+        throw( type="InvalidArgumentException", message="list_ids must be an array of UUIDs." );
+      }
+      if( send_to.list_ids.len() > 50 ){
+        send_to.list_ids = send_to.list_ids.slice(1, 50);
+      }
+    }
+
+    // Validate segment_ids
+    if( send_to.keyExists("segment_ids") ){
+      if( !isArray(send_to.segment_ids) ){
+        throw( type="InvalidArgumentException", message="segment_ids must be an array of UUIDs." );
+      }
+      if( send_to.segment_ids.len() > 10 ){
+        send_to.segment_ids = send_to.segment_ids.slice(1, 10);
+      }
+    }
+
+    if( send_to.keyExists("all") && !isBoolean(send_to.all) ){
+      throw( type="InvalidArgumentException", message="The all property must be a boolean." );
+    }
+
+    setSent_to( send_to );
+    return this;
+  }
+
+  /**
+  * @hint Adds a list ID to the send_to object. Maximum of 50 list IDs allowed.
+  */
+  public any function addListId( required string listId ) {
+    if( !variables.sent_to.keyExists("list_ids") ){
+      variables.sent_to["list_ids"] = [];
+    }
+    if( variables.sent_to["list_ids"].len() >= 50 ){
+      throw( type="InvalidArgumentException", message="A maximum of 50 list IDs is allowed." );
+    }
+    variables.sent_to["list_ids"].append(listId);
+    return this;
+  }
+
+  /**
+  * @hint Adds a segment ID to the send_to object. Maximum of 10 segment IDs allowed.
+  */
+  public any function addSegmentId( required string segmentId ) {
+    if( !variables.sent_to.keyExists("segment_ids") ){
+      variables.sent_to["segment_ids"] = [];
+    }
+    if( variables.sent_to["segment_ids"].len() >= 10 ){
+      throw( type="InvalidArgumentException", message="A maximum of 10 segment IDs is allowed." );
+    }
+    variables.sent_to["segment_ids"].append(segmentId);
+    return this;
+  }
+
+  /**
+  * @hint Sets the all flag in the send_to object.
+  */
+  public any function setAll( required boolean all ) {
+    if( !variables.sent_to.keyExists("all") ) {
+      variables.sent_to["all"] = false;
+    }
+    variables.sent_to["all"] = all;
+    return this;
+  }
+
+  /**
+  * @hint Configures the email content for the Single Send.
+  * @config is a struct containing email configuration details.
+  */
+  public any function emailConfig( required struct config ) {
+    if( config.keyExists("subject") ){
+      subject(config.subject);
+    }
+    if( config.keyExists("html_content") ){
+      htmlContent(config.html_content);
+    }
+    if( config.keyExists("plain_content") ){
+      plainContent(config.plain_content);
+    }
+    if( config.keyExists("generate_plain_content") ){
+      if( !isBoolean(config.generate_plain_content) ){
+        throw( type="InvalidArgumentException", message="generate_plain_content must be a boolean." );
+      }
+      variables.email_config["generate_plain_content"] = config.generate_plain_content;
+    }
+    if( config.keyExists( "design_id") ){
+      variables.email_config.delete("subject");
+      variables.email_config.delete("html_content");
+      variables.email_config.delete("plain_content");
+      variables.email_config["design_id"] = config.design_id;
+    }
+    if( config.keyExists("editor") ){
+      if( !(config.editor == "code" || config.editor == "design") ){
+        throw( type="InvalidArgumentException", message="editor must be 'code' or 'design'." );
+      }
+      variables.email_config["editor"] = config.editor;
+    }
+    if( !config.keyExists("suppression_group_id") && !config.keyExists("custom_unsubscribe_url") ){
+      throw( type="InvalidArgumentException", message="Either suppression_group_id or custom_unsubscribe_url must be provided." );
+    }
+    if( config.keyExists("suppression_group_id") ){
+      variables.email_config["suppression_group_id"] = config.suppression_group_id;
+    }
+    if( config.keyExists("custom_unsubscribe_url") ){
+      variables.email_config["custom_unsubscribe_url"] = config.custom_unsubscribe_url;
+    }
+    if( config.keyExists("sender_id") ){
+      senderId(config.sender_id);
+    }
+    if( config.keyExists("ip_pool") ){
+      variables.email_config["ip_pool"] = config.ip_pool;
+    }
+
+    setEmail_config( variables.email_config );
+    return this;
+  }
+
+  /**
+  * @hint Convenience method for setting the subject of the email.
+  */
+  public any function subject( required string subject ) {
+    variables.email_config["subject"] = subject;
+    return this;
+  }
+
+  /**
+  * @hint Convenience method for setting the HTML content of the email.
+  */
+  public any function htmlContent( required string html ) {
+    variables.email_config["html_content"] = html;
+    return this;
+  }
+
+  /**
+  * @hint Convenience method for setting the plain text content of the email.
+  */
+  public any function plainContent( required string plain ) {
+    variables.email_config["plain_content"] = plain;
+    return this;
+  }
+
+  /**
+  * @hint Convenience method for setting the sender ID.
+  */
+  public any function senderId( required numeric id ) {
+    variables.email_config["sender_id"] = id;
+    return this;
+  }
+
+  /**
+  * @hint Assembles the JSON payload to send to the API. Generally, you shouldn't need to call this directly.
+  */
+  public string function build() {
+    var body = {
+      name: getName(),
+      categories: getCategories(),
+      send_at: getSend_at(),
+      sent_to: getSent_to(),
+      email_config: getEmail_config()
+    };
+
+    return serializeJSON( body );
+  }
+
+  // /**
+  // * @hint converts the array of properties to an array of their keys/values, while filtering those that have not been set
+  // */
+  // private array function getPropertyValues() {
+
+  //   var propertyValues = getProperties().map(
+  //     function( item, index ) {
+  //       return {
+  //         "key" : item.name,
+  //         "value" : getPropertyValue( item.name )
+  //       };
+  //     }
+  //   );
+
+  //   return propertyValues.filter(
+  //     function( item, index ) {
+  //       if ( isStruct( item.value ) )
+  //         return !item.value.isEmpty();
+  //       else
+  //         return item.value.len();
+  //     }
+  //   );
+  // }
+
+  // private array function getProperties() {
+
+  //   var metaData = getMetaData( this );
+  //   var properties = [];
+
+  //   for( var prop in metaData.properties ) {
+  //     properties.append( prop );
+  //   }
+
+  //   return properties;
+  // }
+
+  // private any function getPropertyValue( string key ){
+  //   var method = this["get#key#"];
+  //   var value = method();
+  //   return value;
+  // }
+}

--- a/sendgrid.cfc
+++ b/sendgrid.cfc
@@ -2025,7 +2025,7 @@ component output="false" displayname="SendGrid.cfc"  {
   * @docs https://www.twilio.com/docs/sendgrid/api-reference/segmenting-contacts-v2/get-list-of-segments
   * @hint Retrieve all of your segments.
   */
-  public struct function listSegmentsV2() {
+  public struct function listMarketingSegments() {
     return apiCall( 'GET', '/marketing/segments/2.0' );
   }
 
@@ -2033,7 +2033,7 @@ component output="false" displayname="SendGrid.cfc"  {
   * @docs https://www.twilio.com/docs/sendgrid/api-reference/segmenting-contacts-v2/get-segment-by-id
   * @hint Retrieve a single segment with the given ID.
   */
-  public struct function getSegmentV2( required numeric id ) {
+  public struct function getMarketingSegment( required numeric id ) {
     return apiCall( 'GET', "/marketing/segments/2.0/#id#" );
   }
 
@@ -2041,7 +2041,7 @@ component output="false" displayname="SendGrid.cfc"  {
   * @docs https://www.twilio.com/docs/sendgrid/api-reference/senders/get-list-of-senders
   * @hint Retrieve a list of all sender identities that have been created for your account.
   */
-  public struct function listSendersV2() {
+  public struct function listMarketingSenders() {
     return apiCall( 'GET', '/marketing/senders' );
   }
 
@@ -2049,7 +2049,7 @@ component output="false" displayname="SendGrid.cfc"  {
   * @docs https://www.twilio.com/docs/sendgrid/api-reference/senders/get-specific-sender
   * @hint Retrieve a single sender identity by ID.
   */
-  public struct function getSenderV2( required numeric id ) {
+  public struct function getMarketingSender( required numeric id ) {
     return apiCall( 'GET', "/marketing/senders/#id#" );
   }
 

--- a/sendgrid.cfc
+++ b/sendgrid.cfc
@@ -1890,6 +1890,176 @@ component output="false" displayname="SendGrid.cfc"  {
     return apiCall( 'POST', '/validations/email', {}, body, headers );
   }
 
+  /**
+  * Updated methods for New Marketing Campaigns
+  */
+
+  /**
+  * @docs https://www.twilio.com/docs/sendgrid/api-reference/single-sends/create-single-send
+  * @hint Create a marketing single send.
+  * @singleSend should be an instance of the `helpers.singleSend` component. However, if you want to create and pass in the struct or json yourself, you can.
+  */
+  public struct function createSingleSend( required any singleSend ) {
+    var body = {};
+    if ( isValid( 'component', singleSend ) )
+      body = singleSend.build();
+    else
+      body = singleSend;
+    return apiCall( 'POST', '/marketing/singlesends', {}, body );
+  }
+
+  /**
+  * @docs https://www.twilio.com/docs/sendgrid/api-reference/contacts/add-or-update-a-contact
+  * @hint Add Marketing Campaigns contacts. Note that it also appears to update existing records, so it basically functions like a PATCH.
+  * @contacts is an array of objects, with at minimum, an `email`, 'phone_number_id', 'external_id', or 'anonymous_id' key/value
+  */
+  public struct function addContacts( required array contacts ) {
+    return upsertContacts( 'PUT', contacts );
+  }
+
+  /**
+  * @hint Convenience method for adding a single contact at a time.
+  * @contact Facilitates two means of adding a contact. You can pass in a struct with key/value pairs providing all relevant contact information. Alternatively, you can use this to simply pass in the contact's email address, which is all that is required.
+  * @customFields is a struct with keys corresponding to the custom field names, along with their assigned values
+  */
+  public struct function addContact( required any contact, string first_name = '', string last_name = '', struct customFields = {} ) {
+    return upsertContact( 'PUT', contact, first_name, last_name, customFields );
+  }
+
+  /**
+  * @docs https://www.twilio.com/docs/sendgrid/api-reference/contacts/add-or-update-a-contact
+  * @hint Update one or more Marketing Campaign contacts. Note that it will also add non-existing records.
+  * @contacts is an array of objects, with at minimum, an `email`, 'phone_number_id', 'external_id', or 'anonymous_id' key/value
+  */
+  public struct function updateContacts( required array contacts ) {
+    return upsertContacts( 'PUT', contacts );
+  }
+
+  /**
+  * @hint Convenience method for updating a single contact at a time.
+  * @contact Facilitates two means of updating a contact. You can pass in a struct with key/value pairs providing all relevant contact information. Alternatively, you can use this to simply pass in the contact's email address, which is all that is required.
+  * @customFields is a struct with keys corresponding to the custom field names, along with their assigned values
+  */
+  public struct function updateContact( required any contact, string first_name = '', string last_name = '', struct customFields = {} ) {
+    return upsertContact( 'PUT', contact, first_name, last_name, customFields );
+  }
+
+  /**
+  * @hint shared private method for handling insert/update requests for individual contacts. Deletegates to `upsertContacts()`
+  */
+  private struct function upsertContact( required string method, required any contact, string first_name = '', string last_name = '', struct customFields = {} ) {
+    var contacts = [];
+    var contactData = {};
+
+    if ( isStruct( contact ) )
+      contactData.append( contact );
+    else
+      contactData[ 'email' ] = contact;
+
+    if ( first_name.len() )
+      contactData[ 'first_name' ] = first_name;
+
+    if ( last_name.len() )
+      contactData[ 'last_name' ] = last_name;
+
+    if ( !customFields.isEmpty() )
+      contactData.append( customFields, false );
+
+    contacts.append( contactData );
+
+    return upsertContacts( method, contacts );
+  }
+
+  /**
+  * @hint shared private method for inserting/updating contacts
+  */
+  private struct function upsertContacts( required string method, required array contacts ) {
+    return apiCall( method, '/marketing/contacts', {}, contacts );
+  }
+
+  /**
+  * @docs https://www.twilio.com/docs/sendgrid/api-reference/contacts/get-a-contact-by-id
+  * @hint Retrieve a single contact by ID from your contact database.
+  * @id is the contact ID or email address (which will be automatically converted to the contact ID).
+  */
+  public struct function getContact( required string id ) {
+    return apiCall( 'GET', "/marketing/contacts/#returnContactId( id )#" );
+  }
+
+  /**
+  * @docs https://www.twilio.com/docs/sendgrid/api-reference/contacts/search-contacts
+  * @hint Perform a search on all of your Marketing Campaigns contacts.
+  * @fieldName is the name of a custom field or reserved field
+  * @search is the value to search for within the specified field. Date fields must be unix timestamps. Currently, searches that are formatted as a U.S. date in the format mm/dd/yyyy (1-2 digit days and months, 1-4 digit years) are converted automatically.
+  */
+  public struct function searchContacts( required string fieldName, any search = '' ) {
+    var params = {
+      "#fieldName#" : !isValid( 'USdate', search ) ? search : returnUnixTimestamp( search )
+    };
+    return apiCall( 'GET', "/marketing/contacts/search", params );
+  }
+
+  /**
+  * @docs https://www.twilio.com/docs/sendgrid/api-reference/contacts/add-or-update-a-contact
+  * @hint Add or update a contact and associate them with specific lists.
+  * @contact is the contact's email address or a struct containing contact details.
+  * @listIds is an array of list IDs to which the contact should be added.
+  */
+  public struct function addContactToList( required any contact, required array listIds ) {
+    var body = {};
+    var contactData = {};
+
+    if( isStruct(contact) ){
+      contactData = contact;
+    } else {
+      contactData['email'] = contact;
+    }
+
+    body['contacts'] = [contactData];
+    body['list_ids'] = listIds;
+
+    return apiCall( 'PUT', '/marketing/contacts', {}, body );
+  }
+
+  /**
+  * @docs https://www.twilio.com/docs/sendgrid/api-reference/segmenting-contacts-v2/get-list-of-segments
+  * @hint Retrieve all of your segments.
+  */
+  public struct function listSegmentsV2() {
+    return apiCall( 'GET', '/marketing/segments/2.0' );
+  }
+
+  /**
+  * @docs https://www.twilio.com/docs/sendgrid/api-reference/segmenting-contacts-v2/get-segment-by-id
+  * @hint Retrieve a single segment with the given ID.
+  */
+  public struct function getSegmentV2( required numeric id ) {
+    return apiCall( 'GET', "/marketing/segments/2.0/#id#" );
+  }
+
+  /**
+  * @docs https://www.twilio.com/docs/sendgrid/api-reference/senders/get-list-of-senders
+  * @hint Retrieve a list of all sender identities that have been created for your account.
+  */
+  public struct function listSendersV2() {
+    return apiCall( 'GET', '/marketing/senders' );
+  }
+
+  /**
+  * @docs https://www.twilio.com/docs/sendgrid/api-reference/senders/get-specific-sender
+  * @hint Retrieve a single sender identity by ID.
+  */
+  public struct function getSenderV2( required numeric id ) {
+    return apiCall( 'GET', "/marketing/senders/#id#" );
+  }
+
+  /**
+  * @hint Helper method, which allows for passing in the contact id or email address and returns the id, which is needed. The contact Id is a URL-safe base64 encoding of the contact's lower cased email address
+  */
+  private string function returnContactId( required string id ) {
+    return isValid( 'email', id ) ? toBase64( id ) : id;
+  }
+
 
   // PRIVATE FUNCTIONS
   private struct function apiCall(

--- a/sendgrid.cfc
+++ b/sendgrid.cfc
@@ -2015,8 +2015,13 @@ component output="false" displayname="SendGrid.cfc"  {
       contactData['email'] = contact;
     }
 
+    if( isArray(listIds) ){
+      body['list_ids'] = listIds;
+    } else {
+      body['list_ids'] = listIds.listToArray();
+    }
+
     body['contacts'] = [contactData];
-    body['list_ids'] = listIds;
 
     return apiCall( 'PUT', '/marketing/contacts', {}, body );
   }


### PR DESCRIPTION
SendGrid is deprecating its Legacy Marketing Campaigns API in favor of the newer "Single Sends" functionality. This PR updates our SendGrid API wrapper to reflect that change, to maintain compatibility with SendGrid's updated API moving forward, and to make for an easy migration from legacy to new marketing campaigns.

Changes:
- Added new methods to the API wrapper to support the new endpoints.
- Introduced a singlesend.cfc helper for interacting with the updated marketing campaigns (Single Sends) functionality.